### PR TITLE
chore: remove uritemplate for exposecontroller

### DIFF
--- a/env/values.tmpl.yaml
+++ b/env/values.tmpl.yaml
@@ -17,7 +17,6 @@ expose:
     exposer: Ingress
     http: "true"
     tlsacme: "false"
-    urltemplate: '{{.Service}}-{{.Namespace}}.{{.Domain}}'
 jenkins:
   Servers:
     Global: {}


### PR DESCRIPTION
it seems to conflict with jenkins x templating, 
```

error: generating values.yaml for tree from /tmp/**-helm-apply-289789879/env: failed to render template of file /tmp/**-helm-apply-289789879/env/values.tmpl.yaml: failed to execute Secrets template: /tmp/**-helm-apply-289789879/env/values.tmpl.yaml: template: values.tmpl.yaml:20:20: executing "values.tmpl.yaml" at <.Service>: map has no entry for key "Service"

```